### PR TITLE
No PUSH_PROMISE in idle

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -857,10 +857,15 @@ HTTP2-Settings    = token68
                     later use.  The stream state for the reserved stream transitions to
                     "reserved (remote)".
                   </t>
+                  <t>
+                       Note that the <x:ref>PUSH_PROMISE</x:ref> frame is not sent on the idle
+                       stream, but references the reserved stream in the Promised Stream ID
+                       field.
+                  </t>
                 </list>
               </t>
               <t>
-                Receiving any frames other than <x:ref>HEADERS</x:ref>, <x:ref>PUSH_PROMISE</x:ref>
+                Receiving any frames other than <x:ref>HEADERS</x:ref>
                 or <x:ref>PRIORITY</x:ref> on a stream in this state MUST be treated as a <xref
                 target="ConnectionErrorHandler">connection error</xref> of type
                 <x:ref>PROTOCOL_ERROR</x:ref>.

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -858,9 +858,9 @@ HTTP2-Settings    = token68
                     "reserved (remote)".
                   </t>
                   <t>
-                       Note that the <x:ref>PUSH_PROMISE</x:ref> frame is not sent on the idle
-                       stream, but references the reserved stream in the Promised Stream ID
-                       field.
+                    Note that the <x:ref>PUSH_PROMISE</x:ref> frame is not sent on the idle
+                    stream, but references the newly reserved stream in the Promised Stream ID
+                    field.
                   </t>
                 </list>
               </t>


### PR DESCRIPTION
The current text says that you can receive a PUSH_PROMISE on an idle stream, which I don't believe was ever the intent.  Clarifying that PUSH_PROMISE references an idle stream in the Promised Stream ID field, and is not actually sent on the idle stream.