### PR TITLE
Identifying streams more precisely

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -971,7 +971,7 @@ HTTP2-Settings    = token68
               </t>
               <t>
                 <x:ref>PRIORITY</x:ref> frames received in this state are used to reprioritize
-                streams that depend on the current stream.
+                streams that depend on the identified stream.
               </t>
             </x:lt>
 
@@ -1861,9 +1861,9 @@ HTTP2-Settings    = token68
           The PRIORITY frame can be sent on a stream in any state, though it cannot be sent between
           consecutive frames that comprise a single <xref target="HeaderBlock">header block</xref>.
           Note that this frame could arrive after processing or frame sending has completed, which
-          would cause it to have no effect on the current stream.  For a stream that is in the "half
-          closed (remote)" or "closed" - state, this frame can only affect processing of the current
-          stream and not frame transmission.
+          would cause it to have no effect on the identified stream.  For a stream that is in the
+          "half closed (remote)" or "closed" - state, this frame can only affect processing of the
+          identified stream and its dependent streams and not frame transmission on that stream.
         </t>
         <t>
            The PRIORITY frame can be sent for a stream in the "idle" or "closed" states.  This
@@ -2600,9 +2600,10 @@ HTTP2-Settings    = token68
           </t>
           <t>
             A <x:ref>SETTINGS</x:ref> frame can alter the initial flow control window size for all
-            current streams. When the value of <x:ref>SETTINGS_INITIAL_WINDOW_SIZE</x:ref> changes,
-            a receiver MUST adjust the size of all stream flow control windows that it maintains by
-            the difference between the new value and the old value.
+            streams in the "open" or "half closed (remote)" state. When the value of
+            <x:ref>SETTINGS_INITIAL_WINDOW_SIZE</x:ref> changes, a receiver MUST adjust the size of
+            all stream flow control windows that it maintains by the difference between the new
+            value and the old value.
           </t>
           <t>
             A change to <x:ref>SETTINGS_INITIAL_WINDOW_SIZE</x:ref> can cause the available space in

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2068,8 +2068,7 @@ HTTP2-Settings    = token68
                   control.  The initial value is 2<x:sup>16</x:sup>-1 (65,535) octets.
                 </t>
                 <t>
-                  This setting affects the window size of all streams in the "open" or "half-closed
-                  (remote)" states, see <xref target="StreamStates"/> and <xref
+                  This setting affects the window size of all streams, see <xref
                   target="InitialWindowSize"/>.
                 </t>
                 <t>

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1852,8 +1852,8 @@ HTTP2-Settings    = token68
         </t>
 
         <t>
-          The PRIORITY frame is associated with an existing stream. If a PRIORITY frame is received
-          with a stream identifier of 0x0, the recipient MUST respond with a <xref
+          The PRIORITY frame always identifies a stream. If a PRIORITY frame is received with a
+          stream identifier of 0x0, the recipient MUST respond with a <xref
           target="ConnectionErrorHandler">connection error</xref> of type
           <x:ref>PROTOCOL_ERROR</x:ref>.
         </t>
@@ -2068,8 +2068,9 @@ HTTP2-Settings    = token68
                   control.  The initial value is 2<x:sup>16</x:sup>-1 (65,535) octets.
                 </t>
                 <t>
-                  This setting affects the window size of all streams, including existing streams,
-                  see <xref target="InitialWindowSize"/>.
+                  This setting affects the window size of all streams in the "open" or "half-closed
+                  (remote)" states, see <xref target="StreamStates"/> and <xref
+                  target="InitialWindowSize"/>.
                 </t>
                 <t>
                   Values above the maximum flow control window size of 2<x:sup>31</x:sup>-1 MUST
@@ -2213,9 +2214,10 @@ HTTP2-Settings    = token68
         </t>
 
         <t>
-          PUSH_PROMISE frames MUST be associated with an existing, peer-initiated stream. The stream
-          identifier of a PUSH_PROMISE frame indicates the stream it is associated with.  If the
-          stream identifier field specifies the value 0x0, a recipient MUST respond with a <xref
+          PUSH_PROMISE frames MUST be associated with a peer-initiated stream that is in either the
+          "open" or "half closed (remote)" state. The stream identifier of a PUSH_PROMISE frame
+          indicates the stream it is associated with.  If the stream identifier field specifies the
+          value 0x0, a recipient MUST respond with a <xref
           target="ConnectionErrorHandler">connection error</xref> of type
           <x:ref>PROTOCOL_ERROR</x:ref>.
         </t>
@@ -2654,8 +2656,8 @@ HTTP2-Settings    = token68
         <t>
           The CONTINUATION frame (type=0x9) is used to continue a sequence of <xref
           target="HeaderBlock">header block fragments</xref>.  Any number of CONTINUATION frames can
-          be sent on an existing stream, as long as the preceding frame is on the same stream and is
-          a <x:ref>HEADERS</x:ref>, <x:ref>PUSH_PROMISE</x:ref> or CONTINUATION frame without the
+          be sent, as long as the preceding frame is on the same stream and is a
+          <x:ref>HEADERS</x:ref>, <x:ref>PUSH_PROMISE</x:ref> or CONTINUATION frame without the
           END_HEADERS flag set.
         </t>
 


### PR DESCRIPTION
Two issues were raised about the use of the words "existing" and "current" to refer to streams.  These were a little squishy, so I tightened the language a little.  The text no longer uses either word to refer to streams, instead using stream states to describe where the relevant text applies and favouring "identified" as a fallback.