### PR TITLE
Changed Incorrect "an" to "and" (Editorial)

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -3901,7 +3901,7 @@ HTTP2-Settings    = token68
             A large <xref target="HeaderBlock">header block</xref> can cause an implementation to
             commit a large amount of state.  Header fields that are critical for routing can appear
             toward the end of a header block, which prevents streaming of header fields to their
-            ultimate destination. For this an other reasons, such as ensuring cache correctness,
+            ultimate destination. For this and other reasons, such as ensuring cache correctness,
             means that an endpoint might need to buffer the entire header block.  Since there is no
             hard limit to the size of a header block, some endpoints could be forced commit a large
             amount of available memory for header fields.


### PR DESCRIPTION
Fixes #671 