### PR TITLE
Clarifying what happens in the "idle" stream state

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -847,20 +847,20 @@ HTTP2-Settings    = token68
                     cause a stream to immediately become "half closed".
                   </t>
                   <t>
-                    Sending a <x:ref>PUSH_PROMISE</x:ref> frame reserves an idle stream for
-                    later use.  The stream state for the reserved stream transitions to
-                    "reserved (local)".
+                    Sending a <x:ref>PUSH_PROMISE</x:ref> frame on another stream reserves the idle
+                    stream that is identified for later use.  The stream state for the reserved
+                    stream transitions to "reserved (local)".
                   </t>
                   <t>
-                    Receiving a <x:ref>PUSH_PROMISE</x:ref> frame reserves an idle stream for
-                    later use.  The stream state for the reserved stream transitions to
-                    "reserved (remote)".
+                    Receiving a <x:ref>PUSH_PROMISE</x:ref> frame on another stream reserves an idle
+                    stream that is identified for later use.  The stream state for the reserved
+                    stream transitions to "reserved (remote)".
                   </t>
                 </list>
               </t>
               <t>
-                Receiving any frames other than <x:ref>HEADERS</x:ref>, <x:ref>PUSH_PROMISE</x:ref>
-                or <x:ref>PRIORITY</x:ref> on a stream in this state MUST be treated as a <xref
+                Receiving any frames other than <x:ref>HEADERS</x:ref> or <x:ref>PRIORITY</x:ref> on
+                a stream in this state MUST be treated as a <xref
                 target="ConnectionErrorHandler">connection error</xref> of type
                 <x:ref>PROTOCOL_ERROR</x:ref>.
               </t>

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -835,8 +835,7 @@ HTTP2-Settings    = token68
             <x:lt hangText="idle:">
               <t>
                 <vspace blankLines="0"/>
-                All streams start in the "idle" state.  In this state, no frames have been
-                exchanged.
+                All streams start in the "idle" state.
               </t>
               <t>
                 The following transitions are valid from this state:


### PR DESCRIPTION
This removes the misleading text as observed in #667.  It also clarifies what was potentially misleading text about PUSH_PROMISE from the section.

Closes #667