### PR TITLE
Adding a failure note for decompression failure

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -718,7 +718,7 @@ HTTP2-Settings    = token68
           Header compression is stateful.  One compression context and one decompression context is
           used for the entire connection.  Failure to decompress a header
           block MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref>
-          of type <x:ref>COMRPESSION_ERROR</x:ref>.
+          of type <x:ref>COMPRESSION_ERROR</x:ref>.
         </t>
         <t>
           Each header block is processed as a discrete unit.

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -716,7 +716,12 @@ HTTP2-Settings    = token68
         </t>
         <t>
           Header compression is stateful.  One compression context and one decompression context is
-          used for the entire connection.  Each header block is processed as a discrete unit.
+          used for the entire connection.  Failure to decompress a header
+          block MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref>
+          of type <x:ref>COMRPESSION_ERROR</x:ref>.
+        </t>
+        <t>
+          Each header block is processed as a discrete unit.
           Header blocks MUST be transmitted as a contiguous sequence of frames, with no interleaved
           frames of any other type or from any other stream.  The last frame in a sequence of
           <x:ref>HEADERS</x:ref> or <x:ref>CONTINUATION</x:ref> frames MUST have the END_HEADERS

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -716,9 +716,9 @@ HTTP2-Settings    = token68
         </t>
         <t>
           Header compression is stateful.  One compression context and one decompression context is
-          used for the entire connection.  Failure to decompress a header
-          block MUST be treated as a <xref target="ConnectionErrorHandler">connection error</xref>
-          of type <x:ref>COMPRESSION_ERROR</x:ref>.
+          used for the entire connection.  A decoding error in a header block MUST be treated as a
+          <xref target="ConnectionErrorHandler">connection error</xref> of type
+          <x:ref>COMPRESSION_ERROR</x:ref>.
         </t>
         <t>
           Each header block is processed as a discrete unit.


### PR DESCRIPTION
Proposal to replace #696.  I think that this is a little clearer this way.

Also, it's strange that this was not added earlier, but then sometimes the most obvious things get missed.

cc @RobbySimpson