### PR TITLE
Addressing concerns about the use of an ALPN identifier

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -467,12 +467,14 @@ HTTP2-Settings    = token68
 
       <section anchor="discover-https" title="Starting HTTP/2 for &quot;https&quot; URIs">
         <t>
-          A client that makes a request to an "https" URI uses <xref target="TLS12">TLS</xref>
-          with the <xref target="TLS-ALPN">application layer protocol negotiation extension</xref>.
+          A client that makes a request to an "https" URI uses <xref target="TLS12">TLS</xref> with
+          the <xref target="TLS-ALPN">application layer protocol negotiation (ALPN)
+          extension</xref>.
         </t>
         <t>
-          HTTP/2 over TLS uses the "h2" application token.  The "h2c" token MUST NOT be sent by a
-          client or selected by a server.
+          HTTP/2 over TLS uses the "h2" application identifier.  The "h2c" token MUST NOT be sent by
+          a client or selected by a server; the "h2c" token is reserved from the ALPN identifier
+          space, but describes a protocol that does not use TLS.
         </t>
         <t>
           Once TLS negotiation is complete, both the client and the server MUST send a <xref


### PR DESCRIPTION
... for a non-ALPN/non-TLS purpose.

Raised by Joe Salowey in reviewing the "h2c" ALPN registration.