### PR TITLE
Alternative to #703

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -306,9 +306,8 @@
                 HTTP/2 over TCP is identified.
               </t>
               <t>
-                The "h2c" string is serialized into an ALPN protocol identifier as the three octet
-                sequence: 0x68, 0x32, 0x63. It is reserved from the ALPN identifier space, but
-                describes a protocol that does not use TLS.
+                The "h2c" string is reserved from the ALPN identifier space, but describes a
+                protocol that does not use TLS.
               </t>
             </x:lt>
           </list>

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -477,9 +477,9 @@ HTTP2-Settings    = token68
             extension</xref>.
         </t>
         <t>
-          HTTP/2 over TLS uses the "h2" application token.  The "h2c" token MUST NOT be sent by a
-          client or selected by a server; the "h2c" token is describes a protocol that does not use
-          TLS.
+          HTTP/2 over TLS uses the "h2" protocol identifier.  The "h2c" protocol identifier MUST NOT
+          be sent by a client or selected by a server; the "h2c" protocol identifier describes a
+          protocol that does not use TLS.
         </t>
         <t>
           Once TLS negotiation is complete, both the client and the server MUST send a <xref

--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -305,6 +305,11 @@
                 This identifier is used in the HTTP/1.1 Upgrade header field and in any place where
                 HTTP/2 over TCP is identified.
               </t>
+              <t>
+                The "h2c" string is serialized into an ALPN protocol identifier as the three octet
+                sequence: 0x68, 0x32, 0x63. It is reserved from the ALPN identifier space, but
+                describes a protocol that does not use TLS.
+              </t>
             </x:lt>
           </list>
         </t>
@@ -467,12 +472,14 @@ HTTP2-Settings    = token68
 
       <section anchor="discover-https" title="Starting HTTP/2 for &quot;https&quot; URIs">
         <t>
-          A client that makes a request to an "https" URI uses <xref target="TLS12">TLS</xref>
-          with the <xref target="TLS-ALPN">application layer protocol negotiation extension</xref>.
+          A client that makes a request to an "https" URI uses <xref target="TLS12">TLS</xref> with
+          the <xref target="TLS-ALPN">application layer protocol negotiation (ALPN)
+            extension</xref>.
         </t>
         <t>
           HTTP/2 over TLS uses the "h2" application token.  The "h2c" token MUST NOT be sent by a
-          client or selected by a server.
+          client or selected by a server; the "h2c" token is describes a protocol that does not use
+          TLS.
         </t>
         <t>
           Once TLS negotiation is complete, both the client and the server MUST send a <xref


### PR DESCRIPTION
Moves considerations of defining an ALPN token for a non-TLS-based protocol to 3.1.
Changes "token" to "protocol identifier" in 3.3.