### PR TITLE
Clarifies CONTINUATION frames in state diagram.

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -815,9 +815,11 @@ HTTP2-Settings    = token68
 
         <t>
           Note that this diagram shows stream state transitions and the frames and flags that affect
-          those transitions only.  In this regard, <x:ref>CONTINUATION</x:ref> frames do not result
-          in state transitions; they are effectively part of the <x:ref>HEADERS</x:ref> or
-          <x:ref>PUSH_PROMISE</x:ref> that they follow.  For this purpose, the END_STREAM flag is
+          those transitions only.  In this regard, <x:ref>CONTINUATION</x:ref> frames are not
+          processed independently, but are considered as integral  part of the
+          <x:ref>HEADERS</x:ref> or <x:ref>PUSH_PROMISE</x:ref> frame that they follow; the state
+          transition is caused by the frame carrying the END_HEADERS flag.  For the
+          purpose of state transitions, the END_STREAM flag is
           processed as a separate event to the frame that bears it; a <x:ref>HEADERS</x:ref> frame
           with the END_STREAM flag set can cause two state transitions.
         </t>


### PR DESCRIPTION
I thought the description for handling CONTINUATION frames in the state diagram could be misleading: the last CONTINUATION frame causes a transition, not as an individual frame, but as the last frame containing a header block.