### PR TITLE
Clear up HPACK Section 4.1 "Calculating Table Size"

### DIFF
--- a/draft-ietf-httpbis-header-compression.xml
+++ b/draft-ietf-httpbis-header-compression.xml
@@ -503,14 +503,10 @@
                     entries.
                 </t>
                 <t>
-                    The size of an entry is the sum of its name's length in
-                    octets (as defined in <xref
-                    target="string.literal.representation" />), its value's
-                    length in octets, plus 32.
-                </t>
-                <t>
-                    The size of an entry is calculated using the length of its
-                    name and value without any Huffman encoding applied.
+                    The size of an entry is the sum of its name's length in 
+                    octets, its value's length in octets, plus 32. 
+                    The lengths of name and value are calculated without any 
+                    Huffman encoding applied.
                 </t>
                 <t>
                     <list style="hanging">


### PR DESCRIPTION
It was not quite clear what exactly was referenced with "as defined in Section 5.2". 
In section 5.2, "String length" is defined as the "number of octets used to encode the string". 
This, however, would contradict the (now deleted) second paragraph which explicitly states that the 
length is to be calculated "without any Huffman encoding applied".

Therefore, the reference was deleted and both paragraphs consolidated into one.