### PR TITLE
'at any time' for PRIORITY was confusing people

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -1831,8 +1831,8 @@ HTTP2-Settings    = token68
       <section anchor="PRIORITY" title="PRIORITY">
         <t>
           The PRIORITY frame (type=0x2) specifies the <xref target="StreamPriority">sender-advised
-          priority of a stream</xref>.  It can be sent at any time for any stream, including idle or
-          closed streams.
+          priority of a stream</xref>.  It can be sent in any stream state, including idle or closed
+          streams.
         </t>
         <figure anchor="PRIORITYFramePayload"
           title="PRIORITY Frame Payload">


### PR DESCRIPTION
This was confusing a few people who weren't clear if the prohibition on frame sending for CONTINUATION trumped this or not.  This isn't a perfect fix, but it should be enough.