### PR TITLE
Change upgrade title to say HTTP/1.1

### DIFF
--- a/draft-ietf-httpbis-http2.xml
+++ b/draft-ietf-httpbis-http2.xml
@@ -2861,7 +2861,7 @@ HTTP2-Settings    = token68
           always discard responses at their discretion for other reasons.
         </t>
 
-        <section anchor="informational-responses" title="Upgrading from HTTP/2">
+        <section anchor="informational-responses" title="Upgrading from HTTP/1.1">
           <t>
             HTTP/2 removes support for the 101 (Switching Protocols) informational status code
             (<xref target="RFC7231" x:fmt="," x:rel="#status.101"/>).


### PR DESCRIPTION
I'm not sure if the intention was to have _Upgrading to HTTP/2_ or _Upgrading from HTTP/1.1_, but the current title is misleading and hence demands a change.